### PR TITLE
React 0.14.0-beta3 compat

### DIFF
--- a/lib/find-all-with-class.js
+++ b/lib/find-all-with-class.js
@@ -1,0 +1,44 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = findAllWithClass;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _findAll = require('./find-all');
+
+var _findAll2 = _interopRequireDefault(_findAll);
+
+/**
+ * Finds all instances of components in the tree with a class that matches
+ * `className`.
+ *
+ * This is different to React's `scryRenderedDOMComponentsWithClass` in that
+ * it will check *all* components and not just DOM components.
+ *
+ * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {String} className     the class to find
+ * @return {Array}                all matching components
+ */
+
+function findAllWithClass(tree, className) {
+  return (0, _findAll2['default'])(tree, function (component) {
+    if (_react2['default'].isValidElement(component)) {
+      if (component.props.className != null) {
+        return (' ' + component.props.className + ' ').indexOf(' ' + className + ' ') !== -1;
+      }
+
+      return false;
+    }
+
+    return false;
+  });
+}
+
+module.exports = exports['default'];

--- a/lib/find-all-with-type.js
+++ b/lib/find-all-with-type.js
@@ -1,0 +1,45 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = findAllWithType;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _findAll = require('./find-all');
+
+var _findAll2 = _interopRequireDefault(_findAll);
+
+/**
+ * Finds all instances of components in the tree with a type that matches
+ * `type`.
+ *
+ * This is like both React's `scryRenderedDOMComponentsWithTag` and
+ * `scryRenderedComponentsWithType` as you can supply a component class or a
+ * DOM tag.
+ *
+ * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {Function|String} type the component type or tag to find
+ * @return {Array}                all matching components
+ */
+
+function findAllWithType(tree, type) {
+  return (0, _findAll2['default'])(tree, function (component) {
+    if (_react2['default'].isValidElement(component)) {
+      if (_react2['default'].isValidElement(component)) {
+        return component.type != null && component.type === type;
+      }
+
+      return false;
+    }
+
+    return false;
+  });
+}
+
+module.exports = exports['default'];

--- a/lib/find-all.js
+++ b/lib/find-all.js
@@ -1,0 +1,36 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = findAll;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+/**
+ * Traverses the tree and returns all components that satisfy the function `test`.
+ *
+ * @param  {ReactComponent} tree the tree to traverse
+ * @param  {Function} test       the test for each component
+ * @return {Array}               the components that satisfied `test`
+ */
+
+function findAll(tree, test) {
+  var found = test(tree) ? [tree] : [];
+
+  if (_react2['default'].isValidElement(tree)) {
+    if (_react2['default'].Children.count(tree.props.children) > 0) {
+      _react2['default'].Children.forEach(tree.props.children, function (child) {
+        found = found.concat(findAll(child, test));
+      });
+    }
+  }
+
+  return found;
+}
+
+module.exports = exports['default'];

--- a/lib/find-with-class.js
+++ b/lib/find-with-class.js
@@ -1,0 +1,36 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = findWithClass;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _findAllWithClass = require('./find-all-with-class');
+
+var _findAllWithClass2 = _interopRequireDefault(_findAllWithClass);
+
+/**
+ * Find only one instance of a component in the tree with a class that matches
+ * `className`.
+ *
+ * This is different to React's `findRenderedDOMComponentWithClass` in that
+ * it will check *all* components and not just DOM components.
+ *
+ * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {String} className     the class to find
+ * @return {ReactComponent}       the matching component
+ */
+
+function findWithClass(root, className) {
+  var found = (0, _findAllWithClass2['default'])(root, className);
+
+  if (found.length !== 1) {
+    throw new Error('Did not find exactly once match for class: ' + className);
+  }
+
+  return found[0];
+}
+
+module.exports = exports['default'];

--- a/lib/find-with-type.js
+++ b/lib/find-with-type.js
@@ -1,0 +1,37 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = findWithType;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _findAllWithType = require('./find-all-with-type');
+
+var _findAllWithType2 = _interopRequireDefault(_findAllWithType);
+
+/**
+ * Find only one instance of a components in the tree with a type that matches
+ * `type`.
+ *
+ * This is like both React's `findRenderedDOMComponentWithTag` and
+ * `findRenderedComponentWithType` as you can supply a component class or a
+ * DOM tag.
+ *
+ * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {Function|String} type the component type or tag to find
+ * @return {ReactComponent}       the matching component
+ */
+
+function findWithType(root, type) {
+  var found = (0, _findAllWithType2['default'])(root, type);
+
+  if (found.length !== 1) {
+    throw new Error('Did not find exactly once match for type: ' + type);
+  }
+
+  return found[0];
+}
+
+module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _findAll = require('./find-all');
+
+var _findAll2 = _interopRequireDefault(_findAll);
+
+var _findAllWithClass = require('./find-all-with-class');
+
+var _findAllWithClass2 = _interopRequireDefault(_findAllWithClass);
+
+var _findAllWithType = require('./find-all-with-type');
+
+var _findAllWithType2 = _interopRequireDefault(_findAllWithType);
+
+var _findWithClass = require('./find-with-class');
+
+var _findWithClass2 = _interopRequireDefault(_findWithClass);
+
+var _findWithType = require('./find-with-type');
+
+var _findWithType2 = _interopRequireDefault(_findWithType);
+
+var _isComponentOfType = require('./is-component-of-type');
+
+var _isComponentOfType2 = _interopRequireDefault(_isComponentOfType);
+
+var _isDomComponent = require('./is-dom-component');
+
+var _isDomComponent2 = _interopRequireDefault(_isDomComponent);
+
+var _renderer = require('./renderer');
+
+var _renderer2 = _interopRequireDefault(_renderer);
+
+exports['default'] = {
+  findAll: _findAll2['default'],
+  findAllWithClass: _findAllWithClass2['default'],
+  findAllWithType: _findAllWithType2['default'],
+  findWithClass: _findWithClass2['default'],
+  findWithType: _findWithType2['default'],
+  isComponentOfType: _isComponentOfType2['default'],
+  isDOMComponent: _isDomComponent2['default'],
+  Renderer: _renderer2['default']
+};
+module.exports = exports['default'];

--- a/lib/is-component-of-type.js
+++ b/lib/is-component-of-type.js
@@ -1,0 +1,18 @@
+/**
+ * Returns whether a component instance is of a particular type.
+ * @param  {ReactComponent}   component     the component to check
+ * @param  {Function|String}  componentType the type of component to check against
+ * @return {Boolean}                        whether the element is the supplied type
+ */
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = isComponentOfType;
+
+function isComponentOfType(component, componentType) {
+  return component.type === componentType;
+}
+
+module.exports = exports["default"];

--- a/lib/is-dom-component.js
+++ b/lib/is-dom-component.js
@@ -1,0 +1,18 @@
+/**
+ * Returns whether a component instance is a DOM component.
+ *
+ * @param  {ReactElement}     component
+ * @return {Boolean}          whether the element is a DOM component
+ */
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = isDOMComponent;
+
+function isDOMComponent(component) {
+  return typeof component.type === 'string';
+}
+
+module.exports = exports['default'];

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,61 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactAddonsTestUtils = require('react-addons-test-utils');
+
+var _reactAddonsTestUtils2 = _interopRequireDefault(_reactAddonsTestUtils);
+
+/**
+ * Wraps a React shallow renderer instance that can set a context.
+ */
+
+var Renderer = (function () {
+  /**
+   * Creates a new `Renderer`
+   */
+
+  function Renderer() {
+    _classCallCheck(this, Renderer);
+
+    this.renderer = _reactAddonsTestUtils2['default'].createRenderer();
+  }
+
+  /**
+   * Renders the `Component` into the shallow renderer instance.
+   *
+   * @param  {ReactComponent} Component the component to render
+   * @param  {Object} [context={}]      the context to render the component into
+   * @param  {Object} [props={}]        the props to pass into the component
+   * @return {ReactComponent}           the rendered tree
+   */
+
+  _createClass(Renderer, [{
+    key: 'render',
+    value: function render(Component) {
+      var context = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+      var props = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+
+      this.renderer.render(_react2['default'].createElement(Component, props), context);
+
+      return this.renderer.getRenderOutput();
+    }
+  }]);
+
+  return Renderer;
+})();
+
+exports['default'] = Renderer;
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "babel-eslint": "^3.1.23",
     "eslint": "^0.24.1",
     "eslint-plugin-react": "^2.7.0",
-    "jasmine": "^2.3.1"
+    "jasmine": "^2.3.1",
+    "react-addons-test-utils": "^0.14.0-beta3"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0-alpha"
   }
 }

--- a/specs/renderer-spec.js
+++ b/specs/renderer-spec.js
@@ -1,5 +1,5 @@
 import Renderer from '../src/renderer';
-import React from 'react/addons';
+import React from 'react';
 
 class ComponentWithForm extends React.Component {
   constructor() {

--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/find-all-with-type.js
+++ b/src/find-all-with-type.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,5 @@
-import React from 'react/addons';
-import ReactContext from 'react/lib/ReactContext';
-
-const TestUtils = React.addons.TestUtils;
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 
 /**
  * Wraps a React shallow renderer instance that can set a context.
@@ -22,9 +20,7 @@ export default class Renderer {
    * @return {ReactComponent}           the rendered tree
    */
   render(Component, context = {}, props = {}) {
-    ReactContext.current = context;
     this.renderer.render(<Component {...props} />, context);
-    ReactContext.current = {};
 
     return this.renderer.getRenderOutput();
   }


### PR DESCRIPTION
* Remove `context` direct access
* Replaces `react/addons` with `react-addons-*`

Until react 0.14.0 is shipped, it should be possible to install as:

`npm i -D themouette/react-shallow-testutils`

Or edit the `package.json` with:

``` json
{
  ...
  "devDependencies": { 
    "react-shallow-testutils": "themouette/react-shallow-testutils"
  }
  ...
}
```
