### PR TITLE
React 0.14.0-beta3 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jasmine": "^2.3.1"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0-alpha",
+    "react-addons-test-utils": "^0.14.0-alpha"
   }
 }

--- a/specs/renderer-spec.js
+++ b/specs/renderer-spec.js
@@ -1,5 +1,5 @@
 import Renderer from '../src/renderer';
-import React from 'react/addons';
+import React from 'react';
 
 class ComponentWithForm extends React.Component {
   constructor() {

--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/find-all-with-type.js
+++ b/src/find-all-with-type.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,5 @@
-import React from 'react/addons';
-import ReactContext from 'react/lib/ReactContext';
-
-const TestUtils = React.addons.TestUtils;
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 
 /**
  * Wraps a React shallow renderer instance that can set a context.
@@ -22,9 +20,7 @@ export default class Renderer {
    * @return {ReactComponent}           the rendered tree
    */
   render(Component, context = {}, props = {}) {
-    ReactContext.current = context;
     this.renderer.render(<Component {...props} />, context);
-    ReactContext.current = {};
 
     return this.renderer.getRenderOutput();
   }


### PR DESCRIPTION
* Remove `context` direct access
* Replaces `react/addons` with `react-addons-*`

Until react 0.14.0 is shipped, it should be possible to install as:

`npm i -D themouette/react-shallow-testutils`

Or edit the `package.json` with:

``` json
{
  ...
  "devDependencies": { 
    "react-shallow-testutils": "themouette/react-shallow-testutils"
  }
  ...
}
```

> Replaces #1 As master branch should include **lib** directory to allow npm install