### PR TITLE
Add support for multiple class names

### DIFF
--- a/specs/find-all-with-class-spec.js
+++ b/specs/find-all-with-class-spec.js
@@ -34,6 +34,18 @@ describe('`findAllWithClass`', function() {
     expect(found.length).toBe(1);
   });
 
+  it('should find one `test-class2.test-class2--modified` components', function() {
+    const found = findAllWithClass(this.tree, 'test-class2.test-class2--modified');
+
+    expect(found.length).toBe(1);
+  });
+
+  it('should find no `test-class2.test-class10--modified` components', function() {
+    const found = findAllWithClass(this.tree, 'test-class2.test-class10');
+
+    expect(found.length).toBe(0);
+  });
+
   it('should find no `test-class10` components', function() {
     const found = findAllWithClass(this.tree, 'test-class10');
 

--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -2,6 +2,18 @@ import React from 'react/addons';
 import findAll from './find-all';
 
 /**
+ * Returns true if the given parameter classNameList contains the
+ * given paramter className.
+ *
+ * @param  {String}  classNameList String of all class names
+ * @param  {String}  className     The class name to search for
+ * @return {Boolean}
+ */
+function hasClassName(classNameList, className) {
+  return ` ${classNameList} `.indexOf(` ${className} `) !== -1;
+}
+
+/**
  * Finds all instances of components in the tree with a class that matches
  * `className`.
  *
@@ -16,7 +28,16 @@ export default function findAllWithClass(tree, className) {
   return findAll(tree, component => {
     if (React.isValidElement(component)) {
       if(component.props.className != null) {
-        return ` ${component.props.className} `.indexOf(` ${className} `) !== -1;
+
+        if (className.includes('.')) {
+          const classNameList = className.split('.');
+
+          return classNameList.every(function(val) {
+              return hasClassName(component.props.className, val);
+          });
+        }
+
+        return hasClassName(component.props.className, className);
       }
 
       return false;


### PR DESCRIPTION
Ala jQuery you can now search for multiple classes like `findAllWithClass(tree, 'form-element.firstname');`. I'm not sure if i like the dot as a separator, because it's different form jquery where a dot is front too. What do you think?