### PR TITLE
Changed `render` of `Renderer` to now take a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ npm install react-shallow-testutils
 ### Renderer
 A wrapper around React's [shallow rendering](http://facebook.github.io/react/docs/test-utils.html#shallow-rendering) that makes it easier to use a context.
 
+Takes a function that returns your components to render as well as an optional context:
+
 ```javascript
-this.renderer = new Renderer();
-const componentTree = this.renderer.render(function componentClass, Object context, Object props);
+const renderer = new Renderer();
+const toRender = () => <MyComponent {...props} />;
+const context = {data: 1};
+const componentTree = renderer.render(toRender, context);
 ```
 
 ### isComponentOfType

--- a/specs/find-all-spec.js
+++ b/specs/find-all-spec.js
@@ -41,7 +41,7 @@ class TestWithForm extends React.Component {
 describe('`findAll`', function() {
   beforeEach(function() {
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(TestWithForm, {}, {});
+    this.tree = this.renderer.render(() => <TestWithForm />);
   });
 
   it('should traverse all thirteen items in tree', function() {

--- a/specs/find-all-with-class-spec.js
+++ b/specs/find-all-with-class-spec.js
@@ -20,7 +20,7 @@ describe('`findAllWithClass`', function() {
     }
 
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(TestWithClasses, {}, {});
+    this.tree = this.renderer.render(() => <TestWithClasses />);
   });
 
   it('should find two `test-class` components', function() {

--- a/specs/find-all-with-type-spec.js
+++ b/specs/find-all-with-type-spec.js
@@ -40,7 +40,7 @@ class TestWithTypes extends React.Component {
 describe('`findAllWithType`', function() {
   beforeEach(function() {
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(TestWithTypes, {}, {});
+    this.tree = this.renderer.render(() => <TestWithTypes />);
   });
 
   it('should find three `OtherComponent` components', function() {

--- a/specs/find-with-class-spec.js
+++ b/specs/find-with-class-spec.js
@@ -19,7 +19,7 @@ describe('`findWithClass`', function() {
     }
 
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(TestWithClasses, {}, {});
+    this.tree = this.renderer.render(() => <TestWithClasses />);
   });
 
   it('should find `test-class2` component', function() {

--- a/specs/find-with-type-spec.js
+++ b/specs/find-with-type-spec.js
@@ -28,7 +28,7 @@ class TestWithTypes extends React.Component {
 describe('`findWithType`', function() {
   beforeEach(function() {
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(TestWithTypes, {}, {});
+    this.tree = this.renderer.render(() => <TestWithTypes />);
   });
 
   it('should find `OtherComponent` component', function() {

--- a/specs/is-component-of-type-spec.js
+++ b/specs/is-component-of-type-spec.js
@@ -31,7 +31,7 @@ class Test extends React.Component {
 describe('`isComponentOfType`', function() {
   beforeEach(function() {
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(Test, {}, {});
+    this.tree = this.renderer.render(() => <Test />);
   });
 
   it('should return `true` when a DOM component is the correct type', function() {

--- a/specs/is-dom-component-spec.js
+++ b/specs/is-dom-component-spec.js
@@ -23,7 +23,7 @@ class Test extends React.Component {
 describe('`isDOMComponent`', function() {
   beforeEach(function() {
     this.renderer = new Renderer();
-    this.tree = this.renderer.render(Test, {}, {});
+    this.tree = this.renderer.render(() => <Test />);
   });
 
   it('should return `true` for a DOM component', function() {

--- a/specs/renderer-spec.js
+++ b/specs/renderer-spec.js
@@ -1,16 +1,24 @@
 import Renderer from '../src/renderer';
 import React from 'react/addons';
 
-class ComponentWithForm extends React.Component {
+class MyComponent extends React.Component {
+  static contextTypes = {
+    region: React.PropTypes.string
+  }
   constructor() {
     super();
 
-    this.state = {test: 0};
+    this.state = {test: 'test'};
   }
   render() {
     return (
       <div className='test-class'>
         {this.state.test}
+        {
+          this.context.region
+          ? this.context.region
+          : null
+        }
       </div>
     );
   }
@@ -26,9 +34,32 @@ describe('`Renderer`', function() {
   it('should render a component tree', function() {
     const renderer = new Renderer();
 
-    const tree = renderer.render(ComponentWithForm);
+    const tree = renderer.render(() => <MyComponent />);
 
     expect(tree.type).toBe('div');
-    expect(tree.props.children).toBe(0);
+    expect(tree.props.children[0]).toEqual('test');
+  });
+
+  it('should render a component tree with context', function() {
+    const renderer = new Renderer();
+
+    const tree = renderer.render(() => <MyComponent />, {
+      region: 'UK'
+    });
+
+    expect(tree.type).toBe('div');
+    expect(tree.props.children[0]).toEqual('test');
+    expect(tree.props.children[1]).toEqual('UK');
+  });
+
+  it('should provide the root component', function() {
+    const renderer = new Renderer();
+
+    renderer.render(() => <MyComponent testProp={2} />);
+
+    const root = renderer.root;
+
+    expect(React.addons.TestUtils.isCompositeComponentWithType(root, MyComponent));
+    expect(root.props.testProp).toBe(2);
   });
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -13,17 +13,21 @@ export default class Renderer {
   constructor() {
     this.renderer = TestUtils.createRenderer();
   }
+
+  get root() {
+    return this.renderer._instance ? this.renderer._instance._instance : null;
+  }
+
   /**
    * Renders the `Component` into the shallow renderer instance.
    *
-   * @param  {ReactComponent} Component the component to render
+   * @param  {Function} fn              the function to call to get React elements
    * @param  {Object} [context={}]      the context to render the component into
-   * @param  {Object} [props={}]        the props to pass into the component
    * @return {ReactComponent}           the rendered tree
    */
-  render(Component, context = {}, props = {}) {
+  render(fn, context = {}) {
     ReactContext.current = context;
-    this.renderer.render(<Component {...props} />, context);
+    this.renderer.render(fn(), context);
     ReactContext.current = {};
 
     return this.renderer.getRenderOutput();


### PR DESCRIPTION
- [x] Changed `render` to now just take a Function and the context

With the existing way it's only possible to pass in a Component. This makes it difficult to render a Component that has children. Now that `render` takes a function it's up to the user what gets rendered. 

This is a breaking change but I think it's for the best as it allows for a lot more flexibility; especially since React 0.14 has just been released that allows [stateless function components](http://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components), which means there are now three different types of React components.

As you can now supply a function it's pointless passing the `props` in too. So instead of this:

```javascript
renderer.render(Test, {contextProp: 1}, {testProp: 1});
```

you now do this:

```javascript
renderer.render(() => <Test testProp={1} />, {contextProp: 1})
```

or this:
```javascript
renderer.render(() => 
  <Test testProp={1}>
    <div>test</div>
  </Test>
  , {contextProp: 1})
```