### PR TITLE
Updated to React 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ const context = {data: 1};
 const componentTree = renderer.render(toRender, context);
 ```
 
+`Renderer` also has a `root` getter that allows access to the root component in the rendered output. This is useful for calling methods on the component.
+
+```javascript
+const renderer = new Renderer();
+const toRender = () => <MyComponent {...props} />;
+const context = {data: 1};
+renderer.render(toRender, context);
+const component = renderer.root;
+component.myMethod();
+```
+
 ### isComponentOfType
 Returns whether a component instance is of a particular type.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "jasmine": "^2.3.1"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0"
+  },
+  "dependencies": {
   }
 }

--- a/specs/renderer-spec.js
+++ b/specs/renderer-spec.js
@@ -1,5 +1,6 @@
+import isComponentOfType from '../src/is-component-of-type';
 import Renderer from '../src/renderer';
-import React from 'react/addons';
+import React from 'react';
 
 class MyComponent extends React.Component {
   static contextTypes = {
@@ -59,7 +60,7 @@ describe('`Renderer`', function() {
 
     const root = renderer.root;
 
-    expect(React.addons.TestUtils.isCompositeComponentWithType(root, MyComponent));
+    expect(isComponentOfType(root, MyComponent));
     expect(root.props.testProp).toBe(2);
   });
 });

--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/find-all-with-type.js
+++ b/src/find-all-with-type.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import findAll from './find-all';
 
 /**

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,7 +1,5 @@
-import React from 'react/addons';
-import ReactContext from 'react/lib/ReactContext';
-
-const TestUtils = React.addons.TestUtils;
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 
 /**
  * Wraps a React shallow renderer instance that can set a context.
@@ -11,7 +9,7 @@ export default class Renderer {
    * Creates a new `Renderer`
    */
   constructor() {
-    this.renderer = TestUtils.createRenderer();
+    this.renderer = ReactTestUtils.createRenderer();
   }
 
   get root() {
@@ -26,9 +24,7 @@ export default class Renderer {
    * @return {ReactComponent}           the rendered tree
    */
   render(fn, context = {}) {
-    ReactContext.current = context;
     this.renderer.render(fn(), context);
-    ReactContext.current = {};
 
     return this.renderer.getRenderOutput();
   }


### PR DESCRIPTION
This is an update to #2 by @themouette but with the release version of React 0.14.

We longer need to use `ReactContext` in the `Renderer` so the `Renderer` may be deprecated and removed in future as it doesn't really serve any purpose now (apart from exposing the root component as `root`).