### PR TITLE
Changed from `string.includes` to `string.indexOf`

### DIFF
--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -29,7 +29,7 @@ export default function findAllWithClass(tree, className) {
     if (React.isValidElement(component)) {
       if(component.props.className != null) {
 
-        if (className.includes('.')) {
+        if (className.indexOf('.') !== -1) {
           const classNameList = className.split('.');
 
           return classNameList.every(function(val) {


### PR DESCRIPTION
`String.prototype.includes` is an ES2016 feature that requires using `babel-polyfill`. It's easier just to use `String.prototype.indexOf` instead rather than setting up the `babel-polyfill` and `babel-runtime`.

When using this module inside an application already using `babel-polyfill` everything is fine. However, if someone was using this without `babel` they would hit this issue.

This should fix #11.