### PR TITLE
Updated to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "stage": 0
+  "plugins": ["transform-export-extensions"],
+  "presets": [
+    "es2015",
+    "react"
+   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,12 +29,18 @@
   },
   "homepage": "https://github.com/sheepsteak/react-shallow-testutils#readme",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-eslint": "^4.1.3",
+    "babel-cli": "^6.3.17",
+    "babel-core": "^6.3.26",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-plugin-transform-export-extensions": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
     "jasmine": "^2.3.1",
-    "pre-commit": "^1.1.1"
+    "pre-commit": "^1.1.1",
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0"
   },
   "peerDependencies": {
     "react": "^0.14.0",

--- a/specs/find-all-spec.js
+++ b/specs/find-all-spec.js
@@ -1,4 +1,4 @@
-import findAll from '../src/find-all';
+import {findAll} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/find-all-with-class-spec.js
+++ b/specs/find-all-with-class-spec.js
@@ -1,4 +1,4 @@
-import findAllWithClass from '../src/find-all-with-class';
+import {findAllWithClass} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/find-all-with-type-spec.js
+++ b/specs/find-all-with-type-spec.js
@@ -1,4 +1,4 @@
-import findAllWithType from '../src/find-all-with-type';
+import {findAllWithType} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/find-with-class-spec.js
+++ b/specs/find-with-class-spec.js
@@ -1,4 +1,4 @@
-import findWithClass from '../src/find-with-class';
+import {findWithClass} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/find-with-ref-spec.js
+++ b/specs/find-with-ref-spec.js
@@ -1,4 +1,4 @@
-import findWithRef from '../src/find-with-ref';
+import {findWithRef} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/find-with-type-spec.js
+++ b/specs/find-with-type-spec.js
@@ -1,4 +1,4 @@
-import findWithType from '../src/find-with-type';
+import {findWithType} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/get-mounted-instance-spec.js
+++ b/specs/get-mounted-instance-spec.js
@@ -1,4 +1,4 @@
-import getMountedInstance from '../src/get-mounted-instance';
+import {getMountedInstance} from '../src';
 import React from 'react';
 import {createRenderer, isCompositeComponentWithType} from 'react-addons-test-utils';
 

--- a/specs/is-component-of-type-spec.js
+++ b/specs/is-component-of-type-spec.js
@@ -1,4 +1,4 @@
-import isComponentOfType from '../src/is-component-of-type';
+import {isComponentOfType} from '../src';
 import React from 'react';
 import {createRenderer} from 'react-addons-test-utils';
 

--- a/specs/is-dom-component-spec.js
+++ b/specs/is-dom-component-spec.js
@@ -1,4 +1,4 @@
-import isDOMComponent from '../src/is-dom-component';
+import {isDOMComponent} from '../src';
 import {createRenderer} from 'react-addons-test-utils';
 import React from 'react';
 

--- a/specs/support/jasmine.js
+++ b/specs/support/jasmine.js
@@ -1,4 +1,4 @@
-require('babel/register');
+require('babel-core/register');
 
 process.env.JASMINE_CONFIG_PATH = 'specs/support/jasmine.json';
 

--- a/src/get-mounted-instance.js
+++ b/src/get-mounted-instance.js
@@ -1,3 +1,13 @@
+/**
+ * Returns the mounted component from a shallow renderer.
+ *
+ * This function will be on the shallow renderer itself in React 0.15 but I've
+ * included it in this module for now as it's so useful. It allows you to call
+ * instance functions like `forceUpdate`.
+ *
+ * @param  {ReactShallowRenderer} renderer  the shallow renderer
+ * @return {?ReactComponent}                the matching component
+ */
 export default function(renderer) {
   return renderer._instance ? renderer._instance._instance : null;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,9 @@
-import findAll from './find-all';
-import findAllWithClass from './find-all-with-class';
-import findAllWithType from './find-all-with-type';
-import findWithClass from './find-with-class';
-import findWithRef from './find-with-ref';
-import findWithType from './find-with-type';
-import getMountedInstance from './get-mounted-instance';
-import isComponentOfType from './is-component-of-type';
-import isDOMComponent from './is-dom-component';
-
-export default {
-  findAll,
-  findAllWithClass,
-  findAllWithType,
-  findWithClass,
-  findWithRef,
-  findWithType,
-  getMountedInstance,
-  isComponentOfType,
-  isDOMComponent
-};
+export findAll from './find-all';
+export findAllWithClass from './find-all-with-class';
+export findAllWithType from './find-all-with-type';
+export findWithClass from './find-with-class';
+export findWithRef from './find-with-ref';
+export findWithType from './find-with-type';
+export getMountedInstance from './get-mounted-instance';
+export isComponentOfType from './is-component-of-type';
+export isDOMComponent from './is-dom-component';


### PR DESCRIPTION
- [x] Updated to `babel@6`
- [x] Made a breaking change to how the module exports as it wasn't standards complaint with ES2015 and therefore broke in `babel@6`. Consumers should now use the modules like so:
```javascript
import * as ShallowTestUtils from 'react-shallow-testutils'; // all functions now on ShallowTestUtils

ShallowTestUtils.findWithClass(...);

//or

import {findWithClass} from 'react-shallow-testutils';

findWithClass(...);
```

- [x] Tests now import the functions via the main entry point rather than each file. This is so it imports the way any other library would and to test the change above.

This will get released as `1.0.0` but I'll probably do it as a tag first so people can opt-in and try it.