### PR TITLE
Fix default exports

### DIFF
--- a/specs/index-spec.js
+++ b/specs/index-spec.js
@@ -1,0 +1,38 @@
+import ReactShallowTestUtils from '../src';
+import {
+    findAll,
+    findAllWithClass,
+    findAllWithType,
+    findWithClass,
+    findWithRef,
+    findWithType,
+    getMountedInstance,
+    isComponentOfType,
+    isDOMComponent
+} from '../src';
+
+describe('ReactShallowTestUtils', function() {
+  it('should expose a default object with named functions', function() {
+    expect(typeof ReactShallowTestUtils.findAll).toBe('function');
+    expect(typeof ReactShallowTestUtils.findAllWithClass).toBe('function');
+    expect(typeof ReactShallowTestUtils.findAllWithType).toBe('function');
+    expect(typeof ReactShallowTestUtils.findWithClass).toBe('function');
+    expect(typeof ReactShallowTestUtils.findWithRef).toBe('function');
+    expect(typeof ReactShallowTestUtils.findWithType).toBe('function');
+    expect(typeof ReactShallowTestUtils.getMountedInstance).toBe('function');
+    expect(typeof ReactShallowTestUtils.isComponentOfType).toBe('function');
+    expect(typeof ReactShallowTestUtils.isDOMComponent).toBe('function');
+  });
+
+  it('should expose individually named exports', function() {
+      expect(typeof findAll).toBe('function');
+      expect(typeof findAllWithClass).toBe('function');
+      expect(typeof findAllWithType).toBe('function');
+      expect(typeof findWithClass).toBe('function');
+      expect(typeof findWithRef).toBe('function');
+      expect(typeof findWithType).toBe('function');
+      expect(typeof getMountedInstance).toBe('function');
+      expect(typeof isComponentOfType).toBe('function');
+      expect(typeof isDOMComponent).toBe('function');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
-export findAll from './find-all';
-export findAllWithClass from './find-all-with-class';
-export findAllWithType from './find-all-with-type';
-export findWithClass from './find-with-class';
-export findWithRef from './find-with-ref';
-export findWithType from './find-with-type';
-export getMountedInstance from './get-mounted-instance';
-export isComponentOfType from './is-component-of-type';
-export isDOMComponent from './is-dom-component';
+export const findAll = require('./find-all').default;
+export const findAllWithClass = require('./find-all-with-class').default;
+export const findAllWithType = require('./find-all-with-type').default;
+export const findWithClass = require('./find-with-class').default;
+export const findWithRef = require('./find-with-ref').default;
+export const findWithType = require('./find-with-type').default;
+export const getMountedInstance = require('./get-mounted-instance').default;
+export const isComponentOfType = require('./is-component-of-type').default;
+export const isDOMComponent = require('./is-dom-component').default;
+
+export default {
+    findAll,
+    findAllWithClass,
+    findAllWithType,
+    findWithClass,
+    findWithRef,
+    findWithType,
+    getMountedInstance,
+    isComponentOfType,
+    isDOMComponent
+};


### PR DESCRIPTION
The way that index.js currently exports the utility methods means you can't actually import all of `react-shallow-testutils` as is described in the README.md. This PR fixes that and adds tests for that usage.

Fix default exports in index.js so you can 

```js
import ShallowTestUtils from 'react-shallow-testutils';

expect(ShallowTestUtils.findWithType(...));
```