### PR TITLE
Changes to README and comments to clarify ReactElement usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ expect(myComponent.getCount()).toEqual(10);
 ```
 
 ### isComponentOfType
-Returns whether a component instance is of a particular type.
+Returns whether a `ReactElement` is of a particular type.
 
 ```javascript
-boolean isComponentOfType(ReactComponent component, function componentClass | string tagName)
+boolean isComponentOfType(ReactElement element, function componentClass | string tagName)
 ```
 
 ```javascript
@@ -87,10 +87,10 @@ expect(isComponentOfType(renderer.getRenderOutput(), 'div')).toBe(true);
 ```
 
 ### isDOMComponent
-Returns whether the supplied component is a DOM component or not
+Returns whether the supplied `ReactElement` is a DOM component or not
 
 ```javascript
-boolean isDOMComponent(function component)
+boolean isDOMComponent(ReactElement element)
 ```
 
 ```javascript
@@ -109,10 +109,10 @@ expect(isDOMComponent(renderer.getRenderOutput())).toBe(true);
 ```
 
 ### findAll
-Traverses the tree and returns all components that satisfy the function `test`. A lot of the other functions are implemented in terms of this one.
+Traverses the tree and returns all elements that satisfy the function `test`. A lot of the other functions are implemented in terms of this one.
 
 ```javascript
-array findAll(ReactComponent tree, function test)
+array findAll(ReactElement tree, function test)
 ```
 
 ```javascript
@@ -133,16 +133,16 @@ function MyComponent() {
 const renderer = ReactTestUtils.createRenderer();
 
 renderer.render(<MyComponent />);
-const spans = findAll(renderer.getRenderOutput(), (component) => component.type === 'span');
+const spans = findAll(renderer.getRenderOutput(), (element) => element.type === 'span');
 expect(spans.length).toBe(3);
 ```
 
 ### findAllWithType
-Finds all instances of components in the tree with a type that matches
+Finds all instances of elements in the tree with a type that matches
 `type`. This is like both React's `scryRenderedDOMComponentsWithTag` and `scryRenderedComponentsWithType` as you can supply a component class or a DOM tag.
 
 ```javascript
-array findAllWithType(ReactComponent tree, function componentClass | string tagName)
+array findAllWithType(ReactElement tree, function componentClass | string tagName)
 ```
 
 ```javascript
@@ -172,11 +172,11 @@ expect(findAllWithType(renderer.getRenderOutput(), 'span').length).toBe(2);
 ```
 
 ### findWithType
-Find only one instance of a components in the tree with a type that matches
+Find only one instance of an element in the tree with a type that matches
 `type`. This is like both React's `findRenderedDOMComponentWithTag` and `findRenderedComponentWithType` as you can supply a component class or a DOM tag. It will throw an error if not exactly one instance is found.
 
 ```javascript
-ReactComponent findWithType(ReactComponent tree, function componentClass | string tagName)
+ReactElement findWithType(ReactElement tree, function componentClass | string tagName)
 ```
 
 ```javascript
@@ -207,12 +207,12 @@ expect(findWithType(renderer.getRenderOutput(), 'form')).toThrow();
 
 
 ### findAllWithClass
-Finds all instances of components in the tree with a class that matches `className`. This is different to React's `scryRenderedDOMComponentsWithClass` in that it will check **all** components and not just DOM components.
+Finds all elements in the tree with a `className` prop that matches `className`. This is different to React's `scryRenderedDOMComponentsWithClass` in that it will check **all** components and not just DOM components.
 
-You can pass a `className` like `test-class.test-class--modified` to find a component that has both classes.
+You can pass a `className` like `test-class.test-class--modified` to find an element that has both classes.
 
 ```javascript
-array findAllWithClass(ReactComponent tree, string className)
+array findAllWithClass(ReactElement tree, string className)
 ```
 
 ```javascript
@@ -242,12 +242,12 @@ expect(findAllWithClass(renderer.getRenderOutput(), 'my-span').length).toBe(2);
 ```
 
 ### findWithClass
-Find only one instance of a component in the tree with a class that matches `className`. This is different to React's `findRenderedDOMComponentWithClass` in that it will check **all** components and not just DOM components. It will throw an error if not exactly one instance is found.
+Find only one element in the tree with a `className` prop that matches `className`. This is different to React's `findRenderedDOMComponentWithClass` in that it will check **all** components and not just DOM components. It will throw an error if not exactly one instance is found.
 
-You can pass a `className` like `test-class.test-class--modified` to find a component that has both classes.
+You can pass a `className` like `test-class.test-class--modified` to find an element that has both classes.
 
 ```javascript
-ReactComponent findWithClass(ReactComponent tree, string className)
+ReactElement findWithClass(ReactElement tree, string className)
 ```
 
 ```javascript
@@ -277,10 +277,10 @@ expect(findWithClass(renderer.getRenderOutput(), 'my-span')).toThrow(); // More 
 ```
 
 ### findWithRef
-Find only one instance of a component in the tree with a `ref` that matches `ref`. This is only useful for a `ref` that has been defined as a string and not as a function.
+Find only one element in the tree with a `ref` prop that matches `ref`. This is only useful for a `ref` that has been defined as a string and not as a function.
 
 ```javascript
-ReactComponent findWithRef(ReactComponent tree, string ref)
+ReactElement findWithRef(ReactElement tree, string ref)
 ```
 
 ```javascript

--- a/src/find-all-with-class.js
+++ b/src/find-all-with-class.js
@@ -2,8 +2,8 @@ import React from 'react';
 import findAll from './find-all';
 
 /**
- * Returns true if the given parameter classNameList contains the
- * given paramter className.
+ * Returns true if the given parameter `classNameList` contains the
+ * given parameter `className`.
  *
  * @param  {String}  classNameList String of all class names
  * @param  {String}  className     The class name to search for
@@ -14,15 +14,14 @@ function hasClassName(classNameList, className) {
 }
 
 /**
- * Finds all instances of components in the tree with a class that matches
- * `className`.
+ * Finds all elements in the tree with a class that matches `className`.
  *
  * This is different to React's `scryRenderedDOMComponentsWithClass` in that
  * it will check *all* components and not just DOM components.
  *
- * @param  {ReactComponent} tree  the rendered tree to traverse
- * @param  {String} className     the class to find
- * @return {Array}                all matching components
+ * @param  {ReactElement} tree  the rendered tree to traverse
+ * @param  {String} className   the class to find
+ * @return {Array}              all matching elements
  */
 export default function findAllWithClass(tree, className) {
   return findAll(tree, component => {

--- a/src/find-all-with-type.js
+++ b/src/find-all-with-type.js
@@ -2,16 +2,15 @@ import React from 'react';
 import findAll from './find-all';
 
 /**
- * Finds all instances of components in the tree with a type that matches
- * `type`.
+ * Finds all elements in the tree with a `type` prop that matches `type`.
  *
  * This is like both React's `scryRenderedDOMComponentsWithTag` and
  * `scryRenderedComponentsWithType` as you can supply a component class or a
  * DOM tag.
  *
- * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {ReactElement} tree    the rendered tree to traverse
  * @param  {Function|String} type the component type or tag to find
- * @return {Array}                all matching components
+ * @return {Array}                all matching elements
  */
 export default function findAllWithType(tree, type) {
   return findAll(tree, component => {

--- a/src/find-all.js
+++ b/src/find-all.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
 /**
- * Traverses the tree and returns all components that satisfy the function `test`.
+ * Traverses the tree and returns all elements that satisfy the function `test`.
  *
- * @param  {ReactComponent} tree the tree to traverse
- * @param  {Function} test       the test for each component
- * @return {Array}               the components that satisfied `test`
+ * @param  {ReactElement}   tree the tree to traverse
+ * @param  {Function} test  the test for each component
+ * @return {Array}          the elements that satisfied `test`
  */
 export default function findAll(tree, test) {
   let found = test(tree) ? [tree] : [];

--- a/src/find-with-class.js
+++ b/src/find-with-class.js
@@ -1,15 +1,15 @@
 import findAllWithClass from './find-all-with-class';
 
 /**
- * Find only one instance of a component in the tree with a class that matches
+ * Find only one element in the tree with a `className` prop that matches
  * `className`.
  *
  * This is different to React's `findRenderedDOMComponentWithClass` in that
  * it will check *all* components and not just DOM components.
  *
- * @param  {ReactComponent} tree  the rendered tree to traverse
- * @param  {String} className     the class to find
- * @return {ReactComponent}       the matching component
+ * @param  {ReactElement} tree  the rendered tree to traverse
+ * @param  {String} className   the class to find
+ * @return {ReactElement}       the matching element
  */
 export default function findWithClass(root, className) {
   const found = findAllWithClass(root, className);

--- a/src/find-with-ref.js
+++ b/src/find-with-ref.js
@@ -2,12 +2,11 @@ import React from 'react';
 import findAll from './find-all';
 
 /**
- * Finds component in the tree with a ref that matches
- * `ref`.
+ * Finds an element in the tree with a ref that matches `ref`.
  *
- * @param  {ReactComponent} tree    the rendered tree to traverse
- * @param  {String}                 ref to find
- * @return {ReactComponent}         found component
+ * @param  {ReactElement} tree    the rendered tree to traverse
+ * @param  {String}               ref to find
+ * @return {ReactElement}         the found element
  */
 export default function findWithRef(tree, ref) {
   const found = findAll(tree, component => {

--- a/src/find-with-type.js
+++ b/src/find-with-type.js
@@ -1,16 +1,15 @@
 import findAllWithType from './find-all-with-type';
 
 /**
- * Find only one instance of a components in the tree with a type that matches
- * `type`.
+ * Find only one element in the tree with a `type` prop that matches `type`.
  *
  * This is like both React's `findRenderedDOMComponentWithTag` and
  * `findRenderedComponentWithType` as you can supply a component class or a
  * DOM tag.
  *
- * @param  {ReactComponent} tree  the rendered tree to traverse
+ * @param  {ReactElement} tree    the rendered tree to traverse
  * @param  {Function|String} type the component type or tag to find
- * @return {ReactComponent}       the matching component
+ * @return {ReactElement}         the matching element
  */
 export default function findWithType(root, type) {
   const found = findAllWithType(root, type);

--- a/src/is-component-of-type.js
+++ b/src/is-component-of-type.js
@@ -1,9 +1,9 @@
 /**
- * Returns whether a component instance is of a particular type.
- * @param  {ReactComponent}   component     the component to check
- * @param  {Function|String}  componentType the type of component to check against
+ * Returns whether an element instance is of a particular type.
+ * @param  {ReactElement}     element       the element to check
+ * @param  {Function|String}  componentType the type of element to check against
  * @return {Boolean}                        whether the element is the supplied type
  */
-export default function isComponentOfType(component, componentType) {
-  return component.type === componentType;
+export default function isComponentOfType(element, componentType) {
+  return element.type === componentType;
 }

--- a/src/is-dom-component.js
+++ b/src/is-dom-component.js
@@ -1,9 +1,9 @@
 /**
- * Returns whether a component instance is a DOM component.
+ * Returns whether an element is a DOM element.
  *
- * @param  {ReactElement}     component
- * @return {Boolean}          whether the element is a DOM component
+ * @param  {ReactElement}     element
+ * @return {Boolean}          whether the element is a DOM element
  */
-export default function isDOMComponent(component) {
-  return typeof component.type === 'string';
+export default function isDOMComponent(element) {
+  return typeof element.type === 'string';
 }


### PR DESCRIPTION
Fixes #24.

@aaronbeall, does this help? It's hard to know where to draw the line when talking about `ReactElement` or `ReactComponent`. What is returned by the renderer and used by this module is `ReactElement` but people think of them as `ReactComponent` (or at least I do) because the functions mirror `ReactTestUtils` with names like `isComponentOfType` so I don't want to confuse people more.