### PR TITLE
Add support for React 15 to v1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "react-addons-test-utils": "^0.14.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-addons-test-utils": "^0.14.0 || ^15.0.0-0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
__Note__: This PR is intended to target against commit hash 6e85230 

This PR updates `peerDependencies` to support React 15.x.  I appreciate the 2.x branch provides support for the latest version of React, but that's 1.0 represents the latest stable release (and it's breaking my project's build as a result of the weekly NPM shrinkwrap update).  This is the same approach taken by other popular react library (eg: https://github.com/reactjs/react-redux/blob/master/package.json)

If you are happy for this to land, please consider releasing v1.0.1 on NPM as well.

Thanks for this useful library.